### PR TITLE
Network Manager: Fixes for (mainly) Link-Local IPv6 support

### DIFF
--- a/src/ip6-manager/nm-ip6-manager.c
+++ b/src/ip6-manager/nm-ip6-manager.c
@@ -699,6 +699,18 @@ check_addresses (NMIP6Device *device)
 
 
 		if (IN6_IS_ADDR_LINKLOCAL (addr)) {
+			/* BSC-9653 - don't accept LLv6 addresses that are not a proper translation of the MAC.
+			 *
+			 * NetworkManager goes through an intermittent stage where it assigns a random MAC address to the
+			 * bond (I do not exactly know why and how that happens). If this method accepts the MAC, it
+			 * becomes permant, unless the user forces a re-initialization of the connection using "nmcli conn up"
+			 *
+			 * This patch makes nm-ip6-manager reject the LLv6 address, which leads to it looping and eventually
+			 * grabbing the right address.
+			 *
+			 * FIXME: this seems to take longer than it should. It might be better to ensure that the bond
+			 * interface is created with the correct LLv6 in the first place.
+s			 */
 			if (! llv6_matches_hw_addr(addr, device->hwaddr, device->hwaddr_len)) {
 				nm_log_info (LOGD_IP6, "(%s): ignoring link local address that doesn't match HW address: %s/%d",
 					    device->iface, buf,

--- a/src/ip6-manager/nm-ip6-manager.c
+++ b/src/ip6-manager/nm-ip6-manager.c
@@ -697,7 +697,14 @@ check_addresses (NMIP6Device *device)
 			            rtnl_addr_get_prefixlen (rtnladdr));
 		}
 
+
 		if (IN6_IS_ADDR_LINKLOCAL (addr)) {
+			if (! llv6_matches_hw_addr(addr, device->hwaddr, device->hwaddr_len)) {
+				nm_log_info (LOGD_IP6, "(%s): ignoring link local address that doesn't match HW address: %s/%d",
+					    device->iface, buf,
+					    rtnl_addr_get_prefixlen (rtnladdr));
+				continue;
+			}
 			if (device->state == NM_IP6_DEVICE_UNCONFIGURED)
 				device_set_state (device, NM_IP6_DEVICE_GOT_LINK_LOCAL);
 			device->has_linklocal = TRUE;

--- a/src/nm-netlink-utils.c
+++ b/src/nm-netlink-utils.c
@@ -92,7 +92,6 @@ find_ll_or_other_addresses (struct nl_object *object, void *user_data)
 		return;
 	if (nl_addr_get_len (local) != info->addrlen)
 		return;
-	binaddr = nl_addr_get_binary_addr (local);
 
 	if (info->family == AF_INET6 && IN6_IS_ADDR_LINKLOCAL (addr)) {
 		if (llv6_matches_hw_addr(addr, info->hwaddr, info->hwaddr_len)) {
@@ -200,11 +199,11 @@ nm_netlink_find_address (int ifindex,
  */
 gboolean
 nm_netlink_find_ll_or_addresses (int ifindex,
-                         int family,
-						 guint8* hwaddr,
-						 guint hwaddr_len,
-						 gboolean want_ll,
-						 gboolean want_other)
+		int family,
+		guint8* hwaddr,
+		guint hwaddr_len,
+		gboolean want_ll,
+		gboolean want_other)
 {
 	struct nl_sock *nlh = NULL;
 	struct nl_cache *cache = NULL;

--- a/src/nm-netlink-utils.c
+++ b/src/nm-netlink-utils.c
@@ -71,6 +71,9 @@ find_one_address (struct nl_object *object, void *user_data)
 	}
 }
 
+/** callback function for nl_cache_foreach, used from
+ *  nm_netlink_find_ll_or_addresses.
+ */
 static void
 find_ll_or_other_addresses (struct nl_object *object, void *user_data)
 {
@@ -100,6 +103,12 @@ find_ll_or_other_addresses (struct nl_object *object, void *user_data)
 	}
 }
 
+/** Checks whether the given IPv6 address is a link local address matching
+ * the given given hw (MAC) address according to EUI-64.
+ *
+ * FIXME: this breaks with privacy extensions enabled (we don't have them
+ * in the controller.)
+ */
 gboolean
 llv6_matches_hw_addr(struct in6_addr *addr, guint8 *hwaddr, guint hw_len) {
 	if (hw_len != 6) {
@@ -172,6 +181,23 @@ nm_netlink_find_address (int ifindex,
 	return info.found;
 }
 
+/** Iterates over the netlink addresses of the given interface, and
+ *  checks whether LLv6 and/or other addresses are present.
+ *
+ *  LLv6 addresses are only accepted if they match the MAC according to
+ *  EUI-64.
+ *
+ *  @param family - address family to check
+ *  @param whether the interface should have a LLv6 address
+ *  @param whether the interface should have other addresses of the given family
+ *  @return true if the interface is configured according to both
+ *    want_ll and want_other.
+ *
+ * FIXME: this probably only works for family AF_INET6.
+ *
+ * FIXME: this breaks with privacy extensions enabled (we don't have them
+ * in the controller.)s
+ */
 gboolean
 nm_netlink_find_ll_or_addresses (int ifindex,
                          int family,

--- a/src/nm-netlink-utils.c
+++ b/src/nm-netlink-utils.c
@@ -33,7 +33,11 @@ typedef struct {
 	void *addr;
 	int addrlen;
 	int prefix;
+	guint8* hwaddr;
+	guint hwaddr_len;
 	gboolean found;
+	gboolean found_ll;
+	gboolean found_other;
 } FindAddrInfo;
 
 static void
@@ -64,6 +68,56 @@ find_one_address (struct nl_object *object, void *user_data)
 	if (binaddr) {
 		if (memcmp (binaddr, info->addr, info->addrlen) == 0)
 			info->found = TRUE; /* Yay, found it */
+	}
+}
+
+static void
+find_ll_or_other_addresses (struct nl_object *object, void *user_data)
+{
+	FindAddrInfo *info = user_data;
+	struct rtnl_addr *addr = (struct rtnl_addr *) object;
+	struct nl_addr *local;
+	void *binaddr;
+
+	if (rtnl_addr_get_ifindex (addr) != info->ifindex)
+		return;
+	if (rtnl_addr_get_family (addr) != info->family)
+		return;
+
+	local = rtnl_addr_get_local (addr);
+	if (nl_addr_get_family (local) != info->family)
+		return;
+	if (nl_addr_get_len (local) != info->addrlen)
+		return;
+	binaddr = nl_addr_get_binary_addr (local);
+
+	if (info->family == AF_INET6 && IN6_IS_ADDR_LINKLOCAL (addr)) {
+		if (llv6_matches_hw_addr(addr, info->hwaddr, info->hwaddr_len)) {
+			info->found_ll = TRUE;
+		}
+	} else {
+		info->found_other = TRUE;
+	}
+}
+
+gboolean
+llv6_matches_hw_addr(struct in6_addr *addr, guint8 *hwaddr, guint hw_len) {
+	if (hw_len != 6) {
+		// can't check for non mac addresses
+		return TRUE;
+	}
+	unsigned char *a = addr->s6_addr;
+	if ( (a[8] == hwaddr[0] ^ 2) &&
+	     (a[9] == hwaddr[1]) &&
+	     (a[10] == hwaddr[2]) &&
+	     (a[11] == 0xff ) &&
+	     (a[12] == 0xfe ) &&
+	     (a[13] == hwaddr[3]) &&
+	     (a[14] == hwaddr[4]) &&
+	     (a[15] == hwaddr[5])) {
+		return TRUE;
+	} else {
+		return FALSE;
 	}
 }
 
@@ -116,6 +170,45 @@ nm_netlink_find_address (int ifindex,
 		}
 	}
 	return info.found;
+}
+
+gboolean
+nm_netlink_find_ll_or_addresses (int ifindex,
+                         int family,
+						 guint8* hwaddr,
+						 guint hwaddr_len,
+						 gboolean want_ll,
+						 gboolean want_other)
+{
+	struct nl_sock *nlh = NULL;
+	struct nl_cache *cache = NULL;
+	FindAddrInfo info;
+
+	g_return_val_if_fail (ifindex > 0, FALSE);
+	g_return_val_if_fail (family == AF_INET || family == AF_INET6, FALSE);
+
+	memset (&info, 0, sizeof (info));
+	info.ifindex = ifindex;
+	info.family = family;
+	info.hwaddr = hwaddr;
+	info.hwaddr_len = hwaddr_len;
+	if (family == AF_INET)
+		info.addrlen = sizeof (struct in_addr);
+	else if (family == AF_INET6)
+		info.addrlen = sizeof (struct in6_addr);
+	else
+		g_assert_not_reached ();
+
+	nlh = nm_netlink_get_default_handle ();
+	if (nlh) {
+		rtnl_addr_alloc_cache(nlh, &cache);
+		if (cache) {
+			nl_cache_mngt_provide (cache);
+			nl_cache_foreach (cache, find_ll_or_other_addresses, &info);
+			nl_cache_free (cache);
+		}
+	}
+	return info.found_ll == want_ll && info.found_other == want_other;
 }
 
 struct rtnl_route *

--- a/src/nm-netlink-utils.h
+++ b/src/nm-netlink-utils.h
@@ -28,6 +28,16 @@ gboolean nm_netlink_find_address (int ifindex,
                                   void *addr,  /* struct in_addr or struct in6_addr */
                                   int prefix_);
 
+gboolean nm_netlink_find_ll_or_addresses (int ifindex,
+                         int family,
+						 guint8* hwaddr,
+						 guint hwaddr_len,
+						 gboolean want_ll,
+						 gboolean want_other);
+
+gboolean
+llv6_matches_hw_addr(struct in6_addr *addr, guint8 *hwaddr, guint hw_len);
+
 typedef enum {
 	NMNL_PROP_INVALID = 0,
 	NMNL_PROP_PROT,

--- a/src/nm-netlink-utils.h
+++ b/src/nm-netlink-utils.h
@@ -46,11 +46,11 @@ gboolean nm_netlink_find_address (int ifindex,
  * in the controller.)s
  */
 gboolean nm_netlink_find_ll_or_addresses (int ifindex,
-                         int family,
-						 guint8* hwaddr,
-						 guint hwaddr_len,
-						 gboolean want_ll,
-						 gboolean want_other);
+		int family,
+		guint8* hwaddr,
+		guint hwaddr_len,
+		gboolean want_ll,
+		gboolean want_other);
 
 /** Checks whether the given IPv6 address is a link local address matching
  * the given given hw (MAC) address according to EUI-64.

--- a/src/nm-netlink-utils.h
+++ b/src/nm-netlink-utils.h
@@ -28,6 +28,23 @@ gboolean nm_netlink_find_address (int ifindex,
                                   void *addr,  /* struct in_addr or struct in6_addr */
                                   int prefix_);
 
+/** Iterates over the netlink addresses of the given interface, and
+ *  checks whether LLv6 and/or other addresses are present.
+ *
+ *  LLv6 addresses are only accepted if they match the MAC according to
+ *  EUI-64.
+ *
+ *  @param family - address family to check
+ *  @param whether the interface should have a LLv6 address
+ *  @param whether the interface should have other addresses of the given family
+ *  @return true if the interface is configured according to both
+ *    want_ll and want_other.
+ *
+ * FIXME: this probably only works for family AF_INET6.
+ *
+ * FIXME: this breaks with privacy extensions enabled (we don't have them
+ * in the controller.)s
+ */
 gboolean nm_netlink_find_ll_or_addresses (int ifindex,
                          int family,
 						 guint8* hwaddr,
@@ -35,6 +52,12 @@ gboolean nm_netlink_find_ll_or_addresses (int ifindex,
 						 gboolean want_ll,
 						 gboolean want_other);
 
+/** Checks whether the given IPv6 address is a link local address matching
+ * the given given hw (MAC) address according to EUI-64.
+ *
+ * FIXME: this breaks with privacy extensions enabled (we don't have them
+ * in the controller.)
+ */
 gboolean
 llv6_matches_hw_addr(struct in6_addr *addr, guint8 *hwaddr, guint hw_len);
 


### PR DESCRIPTION
Reviewer: @ronaldchl @3mp4y5 

This makes two changes to network manager:
- change nm-device such that it also checks / validates the IPv6
  config.
- nm-ip6-manager: wait until the initial random Mac has disappeared

Note; the patches in their current form don't cover every case.
In particular, they most likely break compatibility with IPv6
privacy extensions (which we don't use).
